### PR TITLE
Fix/redpacket no rpid

### DIFF
--- a/Maskbook/Extension/UserDefaults+extension.swift
+++ b/Maskbook/Extension/UserDefaults+extension.swift
@@ -253,7 +253,10 @@ final class UserDefaultSettings {
     func isPasswordExpried(_ expiredDate: Date? = nil) -> Bool {
         // fixed: Simultaneous accesses to 0x1068319f0, but modification requires exclusive access.
         guard let expiredDate = expiredDate ?? passwordExpiredDate else {
-            return true
+            // No payment password means it will not expire.
+            // An expiration date will be set once the payment password is set.
+            // For example, if you connect via wallet connect without a payment password, the payment password will not expire.
+            return false
         }
 
         return expiredDate < Date()

--- a/Maskbook/Scene/App/RedPacket/ViewModel/PluginMetaShareViewModel.swift
+++ b/Maskbook/Scene/App/RedPacket/ViewModel/PluginMetaShareViewModel.swift
@@ -33,6 +33,7 @@ class PluginMetaShareViewModel {
         let meta = PluginMeta.redPacket(payload)
         self.shareMeta = meta
         guard showGuideWhenNoPersonaOrProfile() else { return }
+        guard let rpid = payload.basic?.rpid, rpid.isNotEmpty else { return }
 
         coordinator.present(scene: .messageCompose(meta), transition: .modal(animated: true))
     }


### PR DESCRIPTION
- The payment password will not expire if there is no payment password.
- Solve a potential red packet parsing problem that doesn't come out.