### PR TITLE
fix: validate password only when password is not empty

### DIFF
--- a/Maskbook/Scene/Setting/ChangeBackupPassword/ChangeBackupPasswordStep2ViewModel.swift
+++ b/Maskbook/Scene/Setting/ChangeBackupPassword/ChangeBackupPasswordStep2ViewModel.swift
@@ -39,10 +39,12 @@ class ChangeBackupPasswordStep2ViewModel {
 
         let valid = password.isValidBackupPasswordFormat
         
-        if !valid {
+        if password.isNotEmpty, !valid {
             changePasswordError.value = L10n.Scene.SetBackupPassword.tips
             return false
-        } else if !isConfirmPasswordsinConsistent() {
+        } else if newPassword.value?.isNotEmpty == true,
+                  confirmPassword.value?.isNotEmpty == true,
+                  !isConfirmPasswordsinConsistent() {
             changePasswordError.value = L10n.Scene.SetBackupPassword.errorInconsistentPassword
         } else {
             changePasswordError.value = nil

--- a/Maskbook/Scene/Setting/ChangePassword/ChangePasswordViewModel.swift
+++ b/Maskbook/Scene/Setting/ChangePassword/ChangePasswordViewModel.swift
@@ -36,9 +36,11 @@ class ChangePasswordViewModel {
         }
 
         let valid = password.isValidPasswordFormat
-        if !valid {
+        if password.isNotEmpty, !valid {
             changePasswordError.value = L10n.Scene.ChangePassword.passwordDemand
-        } else if !isConfirmPasswordCorrect() {
+        } else if newPassword.value?.isNotEmpty == true,
+                  confirmPassword.value?.isNotEmpty == true,
+                  !isConfirmPasswordCorrect() {
             changePasswordError.value = L10n.Scene.ChangePassword.passwordNotMatch
             return false
         } else {

--- a/Maskbook/Scene/Setting/SetBackupPassword/SetBackupPasswordViewModel.swift
+++ b/Maskbook/Scene/Setting/SetBackupPassword/SetBackupPasswordViewModel.swift
@@ -39,10 +39,12 @@ class SetBackupPasswordViewModel {
 
         let valid = password.isValidBackupPasswordFormat
         
-        if !valid {
+        if password.isNotEmpty, !valid {
             changePasswordError.value = L10n.Scene.SetBackupPassword.tips
             return false
-        } else if !isConfirmPasswordsinConsistent() {
+        } else if newPassword.value?.isNotEmpty == true,
+                  confirmPassword.value?.isNotEmpty == true,
+                  !isConfirmPasswordsinConsistent() {
             changePasswordError.value = L10n.Scene.SetBackupPassword.errorInconsistentPassword
         } else {
             changePasswordError.value = nil

--- a/Maskbook/Scene/Setting/SetPassword/SetPasswordViewModel.swift
+++ b/Maskbook/Scene/Setting/SetPassword/SetPasswordViewModel.swift
@@ -35,10 +35,12 @@ class SetPasswordViewModel {
 
         let valid = password.isValidPasswordFormat
         
-        if !valid {
+        if password.isNotEmpty, !valid {
             changePasswordError.value = L10n.Scene.SetPassword.passwordInvalid
             return false
-        } else if !isConfirmPasswordsinConsistent() {
+        } else if newPassword.value?.isNotEmpty == true,
+                  confirmPassword.value?.isNotEmpty == true,
+                  !isConfirmPasswordsinConsistent() {
             changePasswordError.value = L10n.Scene.ChangePassword.passwordNotMatch
         } else {
             changePasswordError.value = nil


### PR DESCRIPTION
Password check process.
1. password/confirmation password is empty: show password prompt
2. password/confirmation password has a value: check the password/confirmation format
3. password and confirmation password both have values: check for consistency